### PR TITLE
Handle missing Buttondown API token gracefully

### DIFF
--- a/src/pages/newsletter/[slug].astro
+++ b/src/pages/newsletter/[slug].astro
@@ -5,6 +5,10 @@ import Prose from '@layouts/prose.astro';
 import Newsletter from '@sections/newsletter.astro';
 
 export async function getStaticPaths() {
+	if (!import.meta.env.BUTTONDOWN_TOKEN) {
+		return [];
+	}
+
 	const url = new URL(`https://api.buttondown.com/v1/emails`);
 	const options = {
 		method: 'GET',
@@ -19,7 +23,7 @@ export async function getStaticPaths() {
 
 	return posts.map(post => ({
 		params: { slug: post.slug },
-		props: { post }, // Pass the entire post object as a prop
+		props: { post },
 	}));
 }
 

--- a/src/pages/newsletter/index.astro
+++ b/src/pages/newsletter/index.astro
@@ -3,17 +3,21 @@ import Section from '@components/Section.astro';
 import Layout from '@layouts/default.astro';
 import Newsletter from '@sections/newsletter.astro';
 
-const url = new URL(`https://api.buttondown.com/v1/emails`);
-const options = {
-	method: 'GET',
-	headers: {
-		Authorization: `Token ${import.meta.env.BUTTONDOWN_TOKEN}`,
-	},
-};
+let posts = [];
 
-const response = await fetch(url.toString(), options);
-const data = await response.json();
-const posts = data.results;
+if (import.meta.env.BUTTONDOWN_TOKEN) {
+	const url = new URL(`https://api.buttondown.com/v1/emails`);
+	const options = {
+		method: 'GET',
+		headers: {
+			Authorization: `Token ${import.meta.env.BUTTONDOWN_TOKEN}`,
+		},
+	};
+
+	const response = await fetch(url.toString(), options);
+	const data = await response.json();
+	posts = data.results;
+}
 ---
 
 <Layout>


### PR DESCRIPTION
## Summary
Added graceful handling for cases where the Buttondown API token is not configured, preventing build failures and API errors when the environment variable is missing.

## Key Changes
- **Newsletter index page**: Wrapped API fetch logic in a conditional check for `BUTTONDOWN_TOKEN` environment variable, defaulting to an empty posts array if the token is not available
- **Newsletter dynamic routes**: Added early return in `getStaticPaths()` to return an empty array when the token is missing, preventing static page generation attempts without valid credentials
- **Code cleanup**: Removed unnecessary comment in the dynamic routes file

## Implementation Details
These changes ensure that:
- The newsletter feature degrades gracefully when the Buttondown API token is not configured
- Build processes won't fail due to missing authentication credentials
- The application can run in environments where the newsletter feature is not enabled
- Static site generation skips newsletter pages when the API token is unavailable

https://claude.ai/code/session_017d9KoRCo8y9FmQNvwebv9H