### PR TITLE
Fix dark mode not responding to OS theme changes on mobile

### DIFF
--- a/src/assets/theme.css
+++ b/src/assets/theme.css
@@ -1,10 +1,10 @@
 @theme static {
-	--color-accent: '#3DDFC2';
-	--color-background: '#fafafa';
-	--color-default: '#374151';
-	--color-strong: '#111827';
-	--color-subdued: '#6B7280';
-	--color-weak: '#9CA3AF';
+	--color-accent: #3DDFC2;
+	--color-background: #fafafa;
+	--color-default: #374151;
+	--color-strong: #111827;
+	--color-subdued: #6B7280;
+	--color-weak: #9CA3AF;
 
 	--font-sans:
 		Nudica, -apple-system, system-ui, BlinkMacSystemFont, 'Segoe UI',
@@ -35,7 +35,7 @@
 }
 
 @media (prefers-color-scheme: dark) {
-	@theme inline {
+	:root {
 		--color-accent: #00e0b8;
 		--color-background: #000000;
 		--color-default: #f3f4f6;


### PR DESCRIPTION
Two bugs in theme.css prevented dark/light mode switching at runtime:
1. Light mode hex values were wrapped in single quotes (invalid CSS strings)
2. @theme inline inside @media bakes values at build time; replaced with
   :root override so the media query responds correctly at runtime

https://claude.ai/code/session_0125BwHZkMWehqz8WmaYP8gk