### PR TITLE
Add 'AI for Designers' blog post

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "Astro Dev Server",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "site:run"],
+      "port": 4321
+    }
+  ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,14 @@ Newsletter subscription handled via server action in `src/actions/index.ts` usin
 ## Writing Style
 
 - Never use em dashes (—) in written content. Use periods, commas, or colons to separate thoughts instead.
+- Rhythm matters: mix short punchy sentences with longer elaborating ones. Contrast is intentional. Avoid running too many short sentences together — it gets clipped and hard to follow.
+- Fragments are fine for emphasis. ("Judgment. Taste.")
+- Use `---` to break major sections in posts.
+- First-person, conversational, admits uncertainty and mistakes. Never preachy.
+- Share experience honestly. Don't try to convince or convert — just show what you've found.
+- No prescriptive CTAs at the end ("try this," "do that"). Let the last thought land as an honest observation, not a lesson.
+- Dry humor is fine. Forced humor is not.
+- When writing blog posts, after significant style or voice decisions are made, update this section to capture new learnings.
 
 ## Formatting
 

--- a/src/content/posts/2026-03-16-ai-for-designers.md
+++ b/src/content/posts/2026-03-16-ai-for-designers.md
@@ -1,0 +1,46 @@
+---
+title: AI for Designers
+date: 2026-03-16
+---
+
+For a while, I thought AI was a bullshit machine. In many ways, it still is.
+
+The hype has never matched the actual value, and I don't think it ever will. Every week brings a new announcement about something that will change everything, and most of it won't. There's a whole category of AI output that looks the same no matter who prompted it. Generic. Lowest-common-denominator. Made for no one in particular. I've watched enough tools get overhyped and fade out to know what actually sticks. That instinct was right about a lot of this. It just wasn't right about all of it.
+
+What changed wasn't a single moment. It was a slow accumulation of things that actually helped. Research synthesized in minutes instead of hours. Ideas stress-tested before I committed to them. Work that moved faster and landed with more conviction.
+
+---
+
+One thing I don't see said enough: AI doesn't automatically produce good work. You can use it to produce garbage just as easily as something valuable, and a lot of people do just make junk. The quality of what comes out is entirely a function of what you bring to it. Judgment. Taste. A clear point of view on what you're actually trying to make.
+
+AI changes your toolbelt in two directions at once. It makes existing tools faster, and it creates new ones that weren't really accessible before. A few places where I've found it genuinely useful:
+
+- **Thinking through a problem before designing.** When a project lands, I run the brief through an AI conversation before opening Figma. Describe the problem, push on constraints, generate multiple directions and see which ones fall apart immediately. What used to take days of alignment and back-and-forth now happens in an hour. I don't get the design from that conversation. I get better thinking before the design starts.
+
+- **Making sense of research.** Synthesizing user interviews, support tickets, and behavioral data into something actionable used to be one of the slowest parts of the job. It still requires judgment to know what matters, but AI handles the first pass in a fraction of the time.
+
+- **Generating and comparing multiple directions quickly.** The faster you can see the full spectrum of options, the better your final decision. AI lets you explore more branches before committing, so the choice you make is better informed.
+
+- **Prototyping to feel which ideas work.** I built a Kanban board recently. Task states, due dates, overdue indicators, status cycling, list and board view. Working and interactive. About 20 minutes.
+
+With that last point, this is not a "designers should code" post. Coding is an incredibly valuable skill for designers to have, but it's almost beside the point here. What matters is that you can feel which ideas are working instead of imagining them. When prototyping is cheap, you stop debating and start testing. Your judgment does more of the work because execution is no longer the bottleneck.
+
+---
+
+I think about AI adoption as levels, each one building confidence for the next:
+
+1. **Writing and copy.** Error messages, UI text, specs, handoff notes. No tools, no setup. Just start a conversation.
+2. **Research.** Synthesize interviews, support tickets, competitive analysis. Bring your data, get structured insight back.
+3. **Exploration and validation.** Generate directions, stress-test a brief, surface edge cases before committing to anything.
+4. **Prototyping outside production.** Standalone, throwaway code. No local setup required, no stakes if it's rough.
+5. **Prototyping inside production.** Real design system components, real code. Getting the local environment running can be a project in itself, and anything that ships will need engineering review.
+
+That last level is the hardest and also the most optional. Most of what I've described lives in the first four.
+
+---
+
+The bigger opportunity here isn't just working faster. It's rethinking how you see your role.
+
+Designers have often functioned as intermediaries: translating research into requirements, shaping ideas into specs, handing things off and waiting. That work has real value. But when you can validate ideas yourself, prototype them quickly, and iterate in real time, you're not just a step in the process. You're making things, testing them, and driving direction. The way an entrepreneur would. The craft doesn't shrink. The scope of where you apply it does.
+
+A lot of what gets said about AI is still overblown. But underneath the noise, there are tools that actually help, if you bring something real to them.


### PR DESCRIPTION
## Summary

- Adds a new blog post: "AI for Designers" (`src/content/posts/2026-03-16-ai-for-designers.md`)
- Covers the author's arc from AI skeptic to practical adopter, with concrete examples and a 5-level adoption framework
- Also adds `.claude/launch.json` for dev server configuration

## Test plan

- [ ] Visit `/posts/2026-03-16-ai-for-designers` on the preview deploy and confirm the post renders correctly
- [ ] Check the posts listing to confirm the post appears