### PR TITLE
Improve article typography rhythm and heading hierarchy

### DIFF
--- a/src/assets/prose.css
+++ b/src/assets/prose.css
@@ -35,7 +35,7 @@
 
 .prose {
 	font-size: var(--text-lg);
-	line-height: 1.65;
+	line-height: var(--line-height-base);
 }
 
 @variant md {
@@ -54,20 +54,26 @@
 }
 
 .prose h1 {
-	font-size: 2rem;
+	font-size: 1.875em;
 	font-weight: 500;
 	margin-top: 1rlh;
 	margin-bottom: 1rlh;
 }
 
 .prose h2 {
-	font-size: 1.25rem;
+	font-size: 1.5em;
+	font-weight: 500;
+	margin-top: 2rlh;
+	margin-bottom: 1rlh;
+}
+
+.prose h3 {
+	font-size: 1.125em;
 	font-weight: 600;
 	margin-top: 2rlh;
 	margin-bottom: 1rlh;
 }
 
-.prose h3,
 .prose h4,
 .prose h5,
 .prose h6 {

--- a/src/assets/theme.css
+++ b/src/assets/theme.css
@@ -1,8 +1,10 @@
 :root {
-	line-height: 1.65;
+	line-height: var(--line-height-base);
 }
 
 @theme static {
+	--line-height-base: 1.75;
+
 	--color-accent: #3DDFC2;
 	--color-background: #fafafa;
 	--color-default: #374151;


### PR DESCRIPTION
## Summary

- Adds `--line-height-base: 1.75` token to `@theme static` as a single source of truth — both `:root` and `.prose` reference it so `rlh`-based spacing stays in sync with prose line height
- Switches heading font sizes from fixed `rem` to `em` so they scale proportionally when body text bumps from 18px → 20px at `md`
- Size ramp: H1 `1.875em`, H2 `1.5em`, H3 `1.125em`, H4+ `1em` (nothing below 1em/body size)
- Weight: H1/H2 at `500`, H3/H4+ at `600` for a mixed weight hierarchy that uses both size and stroke to reinforce levels

## Test plan

- [ ] Open an article and confirm paragraph line-height feels more open
- [ ] Resize mobile → desktop and confirm headings scale proportionally with the body
- [ ] Confirm H3 is visibly larger than body text and clearly heavier than H2
- [ ] Confirm H2 is visibly lighter (weight) than H3 but larger (size)