### PR TITLE
Fix newsletter markdown rendering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,14 @@ Configured in `tsconfig.json`:
 - Custom utilities in `src/assets/utilities.css` (e.g., `line-length-*` classes)
 - Prose styling for article content in `src/assets/prose.css`
 
+### Newsletter Pipeline
+
+Newsletters are fetched at build time from the Buttondown `/v1/emails` API (not via Astro Content Collections like the rest of `src/content/`). The API returns a single `body` field per email, which can be either markdown or HTML depending on the Buttondown editor mode used when the newsletter was authored.
+
+The `body` is parsed with `marked` before `set:html` in `src/pages/newsletter/[slug].astro`. HTML inside markdown passes through unchanged (per CommonMark spec), so the same code path handles both authoring modes.
+
+`BUTTONDOWN_TOKEN` env var is required at build. Without it, `getStaticPaths()` returns `[]` and no newsletter routes are emitted.
+
 ### Server Actions
 
 Newsletter subscription handled via server action in `src/actions/index.ts` using Buttondown API.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
 				"astro-mail-obfuscation": "^2.3.4",
 				"clsx": "^2.1.0",
 				"date-fns": "^4.1.0",
+				"marked": "^18.0.0",
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0",
 				"react-icons": "^5.5.0",
@@ -12786,6 +12787,18 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/marked": {
+			"version": "18.0.0",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-18.0.0.tgz",
+			"integrity": "sha512-2e7Qiv/HJSXj8rDEpgTvGKsP8yYtI9xXHKDnrftrmnrJPaFNM7VRb2YCzWaX4BP1iCJ/XPduzDJZMFoqTCcIMA==",
+			"license": "MIT",
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 20"
 			}
 		},
 		"node_modules/mdast-util-definitions": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
 		"astro-mail-obfuscation": "^2.3.4",
 		"clsx": "^2.1.0",
 		"date-fns": "^4.1.0",
+		"marked": "^18.0.0",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
 		"react-icons": "^5.5.0",

--- a/src/pages/newsletter/[slug].astro
+++ b/src/pages/newsletter/[slug].astro
@@ -1,5 +1,6 @@
 ---
 import { format } from 'date-fns';
+import { marked } from 'marked';
 
 import Prose from '@layouts/prose.astro';
 
@@ -41,5 +42,5 @@ const niceDate = format(publish_date, 'MMMM d, yyyy');
 			<span>{niceDate}</span>
 		</div>
 	</div>
-	<div set:html={body} />
+	<div set:html={marked.parse(body)} />
 </Prose>


### PR DESCRIPTION
## Summary

Newsletters authored in Buttondown's markdown editor (like "is-it-summer-yet") were displaying raw markdown syntax (`###`, `[text](url)`) because the `body` field was passed directly to `set:html` without parsing.

- Adds `marked` as a dependency and parses newsletter `body` with `marked.parse()` before rendering
- HTML-authored newsletters (like "deadbeats-and-disneyland") continue to work because CommonMark passes inline HTML through unchanged
- Documents the newsletter pipeline in CLAUDE.md

## Self-Review Summary

- **Low complexity** — single-file code change + dependency + docs update
- Verified build passes cleanly (`npm run site:build`)
- Newsletter pages aren't emitted without `BUTTONDOWN_TOKEN` (expected)
- No other files render newsletter `body` — only `[slug].astro` needed the change
- No sanitization added (author-trusted content, per plan)

## What to Look For

- Does the `marked.parse()` approach look right?
- Any concerns about the `marked` dependency choice? (remark is available via `@astrojs/mdx` but heavier for this one-line use case)
- After deploy: verify `/newsletter/is-it-summer-yet/` renders markdown correctly and `/newsletter/deadbeats-and-disneyland/` has no regression

## Testing Constraints

No `BUTTONDOWN_TOKEN` available in CI/dev — rendering must be verified after deploy. Build compilation is confirmed clean.

## References

- Linear: MF-33 (Newest Newsletter rendering funny)
- Build sub-issue: MF-74

https://claude.ai/code/session_01TTDYsMtkNjVPDf2KiBTBRr