### PR TITLE
Remove role titles from all case studies

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -30,7 +30,6 @@ export const collections = {
 				type: z.enum(['case-study', 'showcase']).default('case-study'),
 				featured: z.boolean().optional(), // Appears on homepage
 				intro: z.string(), // Brief description
-				role: z.string().optional(), // Functional role label
 				cover: image(),
 				coverAlt: z.string(),
 			}),

--- a/src/content/work/anvil/index.mdx
+++ b/src/content/work/anvil/index.mdx
@@ -6,7 +6,6 @@ endYear: 2022
 type: showcase
 featured: true
 intro: Built and scaled an enterprise design system from scratch, leading a team that served 385 users across 32 product teams and delivered $5.3M in annual efficiency gains.
-role: Design Systems Lead
 cover: ./imgs/cover.png
 coverAlt: A screenshot of the documentation website for Anvil Design System
 ---

--- a/src/content/work/collaboration-loops/index.mdx
+++ b/src/content/work/collaboration-loops/index.mdx
@@ -6,7 +6,6 @@ endYear: 2026
 type: case-study
 featured: true
 intro: Turning a static meeting document into a living collaboration space, shared between a service team and their customers.
-role: Product Designer
 cover: ./imgs/cover.png
 coverAlt: A TAM check-in loop in Mission Control showing live Cloud Score data, recommendations, and meeting agenda
 ---

--- a/src/pages/work/[slug].astro
+++ b/src/pages/work/[slug].astro
@@ -22,7 +22,6 @@ const {
 	cover,
 	coverAlt,
 	intro,
-	role,
 } = entry.data;
 const { Content } = await render(entry);
 
@@ -55,7 +54,6 @@ function formatYear(
 			<span class="text-subdued text-sm font-medium"
 				>{company}</span
 			>
-			{role && <span class="text-subdued text-sm">{role}</span>}
 			<span class="text-subdued text-sm"
 				>{formatYear(year, endYear, active)}</span
 			>


### PR DESCRIPTION
## Summary

- Remove the `role` field from case study frontmatter (Collaboration Loops, Anvil Design System), the `[slug].astro` page template, and the content collection schema
- Lets the work speak for itself instead of a job title framing the reader's expectations before they've read a word

## Changes

4 files, 4 lines removed:

| File | Change |
|------|--------|
| `src/content/work/collaboration-loops/index.mdx` | Removed `role: Product Designer` from frontmatter |
| `src/content/work/anvil/index.mdx` | Removed `role: Design Systems Lead` from frontmatter |
| `src/pages/work/[slug].astro` | Removed `role` destructuring and conditional render |
| `src/content/config.ts` | Removed `role: z.string().optional()` from work schema |

## Review Summary

Low complexity, engineer self-review. Build passes cleanly, all 5 case study pages render correctly, no role titles appear in output.

## Test plan

- [ ] Verify Collaboration Loops page shows "Mission Cloud" and year range only
- [ ] Verify Anvil page shows "ServiceTitan" and year range only
- [ ] Verify other case studies (DreamHost, Mission Control, YouCaring) still render correctly
- [ ] Confirm build passes with no warnings

Linear: MF-76 / MF-80

https://claude.ai/code/session_019n2Xfs1iL3BorQayYeWSwj