### PR TITLE
Redesign newsletter archive page

### DIFF
--- a/src/pages/newsletter/index.astro
+++ b/src/pages/newsletter/index.astro
@@ -1,6 +1,10 @@
 ---
+import { format } from 'date-fns';
+
 import Section from '@components/Section.astro';
 import Layout from '@layouts/default.astro';
+import Newsletter from '@sections/newsletter.astro';
+
 let posts = [];
 
 if (import.meta.env.BUTTONDOWN_TOKEN) {
@@ -14,20 +18,57 @@ if (import.meta.env.BUTTONDOWN_TOKEN) {
 
 	const response = await fetch(url.toString(), options);
 	const data = await response.json();
-	posts = data.results;
+	posts = data.results
+		.filter(post => post.slug && post.publish_date)
+		.sort(
+			(a, b) =>
+				new Date(b.publish_date).valueOf() -
+				new Date(a.publish_date).valueOf(),
+		);
 }
+
+const postsByYear = posts.reduce((acc, post) => {
+	const year = new Date(post.publish_date).getFullYear();
+	if (!acc[year]) {
+		acc[year] = [];
+	}
+	acc[year].push(post);
+	return acc;
+}, {});
+
+const years = Object.keys(postsByYear)
+	.map(Number)
+	.sort((a, b) => b - a);
 ---
 
 <Layout>
-	{
-		posts.length > 0 && (
-			<Section title="Newsletters">
-				{posts.map(post => (
-					<a href={`/newsletter/${post.slug}`}>
-						<h2>{post.subject}</h2>
-					</a>
-				))}
-			</Section>
-		)
-	}
+	<div class="space-y-5">
+		{
+			years.map(year => (
+				<Section title={year.toString()}>
+					<ul class="space-y-2">
+						{postsByYear[year].map(post => (
+							<li>
+								<a
+									href={`/newsletter/${post.slug}`}
+									class="group flex items-baseline gap-2 transition-transform hover:translate-x-1 focus:outline-0"
+								>
+									<time class="text-subdued font-mono font-medium whitespace-nowrap">
+										{format(
+											new Date(post.publish_date),
+											'MMM dd',
+										)}
+									</time>
+									<span class="font-medium">
+										{post.subject}
+									</span>
+								</a>
+							</li>
+						))}
+					</ul>
+				</Section>
+			))
+		}
+		<Newsletter />
+	</div>
 </Layout>


### PR DESCRIPTION
## Summary

Redesigns the newsletter archive page (`/newsletter/`) to match the quality and patterns of the articles page (`/articles/`):

- **Year grouping** — newsletters grouped by publish year, sorted descending
- **Formatted dates** — `MMM dd` format in monospace font, matching articles
- **Hover/focus states** — `translate-x-1` transition, `focus:outline-0`
- **Subscribe section** — imported at the bottom of the page
- **Entry filtering** — only entries with both `slug` and `publish_date` are rendered, preventing broken links from drafts

Single-file change to `src/pages/newsletter/index.astro`. Follows the exact same pattern as `src/pages/articles/index.astro`.

**Linear ticket:** [MF-32](https://linear.app/matts-cool-company/issue/MF-32/newsletter-archive-redesign)

## Self-review

- Verified all 7 acceptance criteria from the plan are met
- Build passes cleanly (`npm run build`)
- No new dependencies (uses existing `date-fns`)
- Matches articles page typography, spacing, and interaction patterns exactly
- Empty state works: when no API data, only the subscribe section renders
- Semantic HTML: `<ul>/<li>`, `<time>`, `<a>` elements for accessibility

## What to look for

- Whether the date format (`MMM dd`) feels right vs alternatives like `MMM d` or full dates
- Whether the subscribe section placement at the bottom works or if it should be more prominent
- The `publish_date` field from the Buttondown API — confirm it's always present on published emails

https://claude.ai/code/session_01U9bEH1J8JVvMPUKJpjJP7Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9bEH1J8JVvMPUKJpjJP7Q)_