### PR TITLE
Remove Mission Control from homepage featured work

### DIFF
--- a/src/content/work/mission-control/index.mdx
+++ b/src/content/work/mission-control/index.mdx
@@ -4,7 +4,6 @@ company: Mission Cloud
 year: 2022
 active: true
 type: case-study
-featured: true
 role: Product Designer & Frontend Developer
 intro: Led design and frontend development for Mission Cloud's customer platform, owning the entire UX and frontend from concept to production.
 cover: ./cover.png


### PR DESCRIPTION
## Summary
- Dropped `featured: true` from `src/content/work/mission-control/index.mdx` so the case study no longer appears on the homepage featured list.

## Test plan
- [ ] Confirm Mission Control is gone from the homepage featured work section
- [ ] Confirm `/work/mission-control` still renders