### PR TITLE
Fix Card component light-mode styling

### DIFF
--- a/src/components/Card.astro
+++ b/src/components/Card.astro
@@ -8,7 +8,7 @@ const classes = cx(
 	compact ? 'p-2' : 'p-4',
 	accent
 		? 'border-accent/30 bg-accent/5'
-		: 'border-[rgba(255,255,255,0.06)] bg-[hsl(0,0%,6%)]',
+		: 'border-default/10 bg-default/5',
 	className,
 );
 


### PR DESCRIPTION
## Summary
- `Card.astro` non-accent variant hardcoded `border-[rgba(255,255,255,0.06)] bg-[hsl(0,0%,6%)]`, so the surface stayed dark in light mode.
- Swap to `border-default/10 bg-default/5`. The `--color-default` token already inverts via `@media (prefers-color-scheme: dark)` in `theme.css`, so the same utilities now tint correctly in both modes (faint dark wash on light bg, faint light wash on dark bg).
- Accent variant unchanged.

## Test plan
- [ ] Light mode: visit `/work/anvil`, `/work/mission-control`, `/work/collaboration-loops` and confirm Card surfaces sit a hair below the page background instead of black.
- [ ] Dark mode: same pages, confirm Card surfaces still feel subtly elevated (look comparable to before).
- [ ] Accent Card (where `accent` prop is set) is unchanged.