### PR TITLE
Add deck-planning guidance to decks/CLAUDE.md

### DIFF
--- a/src/pages/decks/CLAUDE.md
+++ b/src/pages/decks/CLAUDE.md
@@ -168,6 +168,118 @@ These are **rules**, not suggestions.
 - Use smart quotes (`'` `"`) in slide content where the Figma source has
   them.
 
+## How to think about a deck
+
+Before any slides, decide what kind of deck this is and write the spine.
+The format is honest: the deck reads thin if these aren't sharp upstream.
+
+### Deck types
+
+- **Case study deck.** One project, deep. The spine *is* the project,
+  told roughly in the order experienced. `2024-anvil-case-study` is the
+  reference.
+- **Thesis deck.** One argument, 2 to 4 projects as evidence. The spine
+  is the claim. Each project is sized by how strongly it supports the
+  claim.
+
+Both are mono-narrative. Not necessarily mono-project. One story spine
+runs through every slide.
+
+### Invariants (across all decks)
+
+- Three acts: who you are, then the work, then reflection.
+- TOC interstitials between sections. No standalone section banners.
+- Subtitle carries each slide's identity. Title stays the deck name.
+- Distill text into lists. Prose is rare and short when it appears.
+- Images carry meaning when they can. Bleed them when they're hero
+  content.
+- Don't frame quotes. Don't include CTAs. Don't summarize for the
+  audience.
+- Slide count is editorial. What got slides is what mattered. What
+  didn't get slides doesn't go in.
+
+### Act I and Act III are kits, not templates
+
+Assemble per deck. Bring what argues *this* deck specifically.
+
+Act I parts:
+
+- Title (always)
+- Work History (almost always; credibility frame)
+- Design Principles (when the audience cares about taste / approach)
+- Management Principles (when the role or thesis involves leading teams)
+- A custom "about" slide (when the deck has a specific framing to set up)
+- TOC
+
+Act III parts:
+
+- Why Me (evergreen)
+- Testimonials (optional; recurate per deck. Pick quotes that reinforce
+  *this* deck's thesis, not generic ones.)
+- Thank You (always)
+
+### Planning a case study deck
+
+Act II beats, in order:
+
+1. Context. Company, role, team, timeline.
+2. Kickoff. Interviews and challenges (the gap that motivated the work).
+3. Prior art. Research or audit.
+4. Personas. 1 to 4 named people with traits and pain points. Count is
+   signal: one persona means a single-user story; four means the problem
+   cuts across a constellation.
+5. Problem statement. One sentence, load-bearing phrases highlighted.
+6. Framework (optional). A diagram of your process. Use it when the
+   methodology itself is the interesting move; skip otherwise.
+7. Execution. One or two slides per framework phase, each anchored by an
+   artifact.
+8. Outputs. System principles, components, etc.
+9. Results. Quantified outcomes (CardGridSlide pattern).
+
+Results land at the *end* of Act II, not the middle. The argument builds
+first, the payoff lands last.
+
+### Planning a thesis deck
+
+Act II beats:
+
+1. Thesis statement. One sentence, load-bearing phrases highlighted.
+2. Why this thesis (optional). What pattern the thesis is reacting to.
+   Skip if it adds nothing.
+3. Evidence. 2 to 4 project mini-arcs. Each project gets:
+   - Context (1 slide). Stripped down vs. a case study deck.
+   - The decision specific to the thesis (1 to 2 slides). For a
+     "highest-leverage problem" thesis, this is the leverage decision.
+     For a different thesis, a different beat.
+   - What shipped and the outcome (1 slide).
+4. Synthesis. One slide pulling the pattern across all the projects.
+
+The variable beat in step 3 is the most important one to nail. Every
+project section must demonstrate that specific verb.
+
+Project depth signals which evidence is strongest. A 5-slide project is
+your headline; a 2-slide project is a supporting example. Use the count.
+
+### Pre-slide checklist
+
+Before drafting any slide:
+
+1. Write the thesis (or project arc) in one sentence. If you can't write
+   it crisply, the deck isn't ready.
+2. For thesis decks: list candidate projects. Cut anything that doesn't
+   *demonstrate* the thesis (versus "happens to be a project you worked
+   on").
+3. For each surviving project, write the load-bearing decision in one
+   sentence.
+4. Decide depth per project.
+5. Draft the synthesis (thesis) or results (case study) slide first. If
+   you can't articulate the takeaway, iterate the thesis before drafting
+   anything else.
+6. Assemble Act I and III from the parts bin to set up and close *this*
+   deck specifically.
+
+The work is upstream of any template.
+
 ## How to build a new slide
 
 1. Get the Figma reference. Either Matt links a node, or look up the

--- a/src/pages/decks/CLAUDE.md
+++ b/src/pages/decks/CLAUDE.md
@@ -241,11 +241,15 @@ first, the payoff lands last.
 
 ### Planning a thesis deck
 
-**The thesis is a planning artifact, not a slide.** Write it down to
-choose projects, decide depth, and order Act II. The audience never sees
-it stated. If the thesis is clear from the projects you picked and the
-order you put them in, the deck worked. If not, it didn't. Show, don't
-tell.
+**The thesis lives in `index.astro`'s `meta` object, not as a slide.**
+Write it down to choose projects, decide depth, and order Act II. The
+audience never sees it stated. If the thesis is clear from the projects
+you picked and the order you put them in, the deck worked. If not, it
+didn't. Show, don't tell.
+
+The `meta.thesis` field (see "How to build a new deck") preserves the
+sentence you spent crafting so it doesn't get lost. It's also what a
+future maintainer reads first to understand what the deck is arguing.
 
 Act II is project mini-arcs, end to end. 2 to 4 projects, each gets:
 
@@ -314,16 +318,30 @@ imports accordingly.
 
 1. Create `src/pages/decks/YYYY-<slug>/` with `index.astro`, `_slides/`,
    `images/`.
-2. `index.astro` mounts `<DeckShell>` + `<Deck title="…">`. Title goes on
-   `<Deck>` so it flows to slides via context.
-3. Use a top-level TOC array (`const toc = ['Section 1', 'Section 2', …]`)
+2. At the top of `index.astro`, define a `meta` const:
+
+   ```ts
+   const meta = {
+       title: 'Deck Title',
+       description: 'One-line description for SEO/head',
+       thesis: 'One sentence. The deck\'s argument, kept private.',
+   };
+   ```
+
+   `<DeckShell {...meta}>` uses `title` and `description` for the HTML
+   head. `thesis` is ignored by the shell but preserved as the source of
+   truth for what the deck argues. The audience never sees it. See "How
+   to think about a deck" for what belongs there.
+3. Mount the deck: `<DeckShell {...meta}><Deck title={meta.title}>`.
+   Title goes on `<Deck>` so it flows to slides via context.
+4. Use a top-level TOC array (`const toc = ['Section 1', 'Section 2', …]`)
    and render `<TocSlide items={toc} />` (no active) at the start, plus
    `<TocSlide items={toc} active="…" />` before each section.
-4. To reuse a slide from another deck, either `import` it directly
-   (sharing — old deck's edits propagate) or `cp` the file into the new
+5. To reuse a slide from another deck, either `import` it directly
+   (sharing; old deck's edits propagate) or `cp` the file into the new
    `_slides/` and tweak (true freezing).
-5. Images: copy what you need into the new deck's `images/`. Even if
-   logos are the same as another deck, copy — assets freeze with the
+6. Images: copy what you need into the new deck's `images/`. Even if
+   logos are the same as another deck, copy. Assets freeze with the
    deck too.
 
 ## Freezing principle

--- a/src/pages/decks/CLAUDE.md
+++ b/src/pages/decks/CLAUDE.md
@@ -241,15 +241,15 @@ first, the payoff lands last.
 
 ### Planning a thesis deck
 
-**The thesis lives in `index.astro`'s `meta` object, not as a slide.**
-Write it down to choose projects, decide depth, and order Act II. The
-audience never sees it stated. If the thesis is clear from the projects
-you picked and the order you put them in, the deck worked. If not, it
-didn't. Show, don't tell.
+**The thesis lives in `index.astro`'s `meta.description`, not as a
+slide.** Write it down to choose projects, decide depth, and order
+Act II. The audience never sees it stated. If the thesis is clear from
+the projects you picked and the order you put them in, the deck worked.
+If not, it didn't. Show, don't tell.
 
-The `meta.thesis` field (see "How to build a new deck") preserves the
-sentence you spent crafting so it doesn't get lost. It's also what a
-future maintainer reads first to understand what the deck is arguing.
+`meta.description` is where the sentence you spent crafting lives. It's
+also what a future maintainer reads first to understand what the deck
+is arguing. See "How to build a new deck" for the convention.
 
 Act II is project mini-arcs, end to end. 2 to 4 projects, each gets:
 
@@ -323,15 +323,16 @@ imports accordingly.
    ```ts
    const meta = {
        title: 'Deck Title',
-       description: 'One-line description for SEO/head',
-       thesis: 'One sentence. The deck\'s argument, kept private.',
+       description: 'One sentence stating the deck\'s argument.',
    };
    ```
 
-   `<DeckShell {...meta}>` uses `title` and `description` for the HTML
-   head. `thesis` is ignored by the shell but preserved as the source of
-   truth for what the deck argues. The audience never sees it. See "How
-   to think about a deck" for what belongs there.
+   `<DeckShell {...meta}>` reads both. `title` is the document title.
+   `description` carries the deck's thesis (or project arc) as the
+   source of truth for what the deck argues; it lands in the HTML
+   `<meta name="description">` but the deck is robots-disallowed, so
+   no crawler reads it and no slide displays it. See "How to think
+   about a deck" for what belongs there.
 3. Mount the deck: `<DeckShell {...meta}><Deck title={meta.title}>`.
    Title goes on `<Deck>` so it flows to slides via context.
 4. Use a top-level TOC array (`const toc = ['Section 1', 'Section 2', …]`)

--- a/src/pages/decks/CLAUDE.md
+++ b/src/pages/decks/CLAUDE.md
@@ -241,21 +241,23 @@ first, the payoff lands last.
 
 ### Planning a thesis deck
 
-Act II beats:
+**The thesis is a planning artifact, not a slide.** Write it down to
+choose projects, decide depth, and order Act II. The audience never sees
+it stated. If the thesis is clear from the projects you picked and the
+order you put them in, the deck worked. If not, it didn't. Show, don't
+tell.
 
-1. Thesis statement. One sentence, load-bearing phrases highlighted.
-2. Why this thesis (optional). What pattern the thesis is reacting to.
-   Skip if it adds nothing.
-3. Evidence. 2 to 4 project mini-arcs. Each project gets:
-   - Context (1 slide). Stripped down vs. a case study deck.
-   - The decision specific to the thesis (1 to 2 slides). For a
-     "highest-leverage problem" thesis, this is the leverage decision.
-     For a different thesis, a different beat.
-   - What shipped and the outcome (1 slide).
-4. Synthesis. One slide pulling the pattern across all the projects.
+Act II is project mini-arcs, end to end. 2 to 4 projects, each gets:
 
-The variable beat in step 3 is the most important one to nail. Every
-project section must demonstrate that specific verb.
+- Context (1 slide). Stripped down vs. a case study deck.
+- The decision specific to the thesis (1 to 2 slides). For a
+  "highest-leverage problem" thesis, this is the leverage decision. For
+  a different thesis, a different beat.
+- What shipped and the outcome (1 slide).
+
+The decision beat is the most important one to nail. Every project
+section must demonstrate the same verb. Order the projects so the
+cumulative reading lands the thesis without anyone naming it.
 
 Project depth signals which evidence is strongest. A 5-slide project is
 your headline; a 2-slide project is a supporting example. Use the count.
@@ -264,17 +266,20 @@ your headline; a 2-slide project is a supporting example. Use the count.
 
 Before drafting any slide:
 
-1. Write the thesis (or project arc) in one sentence. If you can't write
-   it crisply, the deck isn't ready.
+1. Write the one-sentence purpose. For a case study deck, the project
+   arc. For a thesis deck, the thesis. The thesis stays private; the
+   audience inducts it from the work. If you can't write the sentence
+   crisply, the deck isn't ready.
 2. For thesis decks: list candidate projects. Cut anything that doesn't
    *demonstrate* the thesis (versus "happens to be a project you worked
    on").
 3. For each surviving project, write the load-bearing decision in one
    sentence.
 4. Decide depth per project.
-5. Draft the synthesis (thesis) or results (case study) slide first. If
-   you can't articulate the takeaway, iterate the thesis before drafting
-   anything else.
+5. For case study decks, draft the results slide first; it's the
+   endpoint everything else aims at. For thesis decks, draft the
+   strongest project's decision slide first; it sets the bar for the
+   others.
 6. Assemble Act I and III from the parts bin to set up and close *this*
    deck specifically.
 


### PR DESCRIPTION
## Summary

- Adds a "How to think about a deck" section to `src/pages/decks/CLAUDE.md` so future Claude sessions (and future me) have a clear framing for planning a new deck, not just building one.
- Covers two deck types so far (case study vs thesis), the invariants that survive any deck, Act I and Act III as remixable parts kits, per-type planning beats, and a pre-slide checklist. The section sits between Conventions and "How to build a new slide" so the doc reads as rules → narrative planning → mechanics.

## Test plan

- [ ] `npm run build` completes without errors
- [ ] Read through the new section in `src/pages/decks/CLAUDE.md` and confirm it captures the framing you want to keep
- [ ] The Pre-slide checklist + Planning a thesis deck subsections are useful for planning the next deck