### PR TITLE
chore(content): drop stale featured-image frontmatter from 2012 post

### DIFF
--- a/src/content/posts/2012-11-06-lois-lane.md
+++ b/src/content/posts/2012-11-06-lois-lane.md
@@ -1,6 +1,5 @@
 ---
 title: Lois Lane
-featured-image: lois.png
 date: 2012-11-06
 ---
 


### PR DESCRIPTION
## Summary
- Remove `featured-image: lois.png` from `src/content/posts/2012-11-06-lois-lane.md`.
- The referenced `lois.png` file doesn't exist in the repo, and no template consumes the `featured-image` frontmatter key.
- Surfaced by a blog-post image audit (see data/post-imgs-ba/report.md in the firstmate workspace).

## Test plan
- [x] `npm run build` passes locally.
- [x] `grep featured-image src/` returns nothing.