### PR TITLE
Revive /docs with brainstorm scaffolds and reference docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ src/layouts/favicon.html
 
 # Netlify specific
 .netlify/
+.scratch/

--- a/src/components/Callout.astro
+++ b/src/components/Callout.astro
@@ -1,0 +1,15 @@
+---
+const { tone = 'note' } = Astro.props;
+
+const styles = {
+	note: 'border-hairline bg-subtle',
+	scaffold:
+		'border-dashed border-amber-400/60 bg-amber-50/50 dark:border-amber-400/40 dark:bg-amber-950/20',
+};
+
+const cls = styles[tone] ?? styles.note;
+---
+
+<aside class={`not-prose my-6 rounded-md border p-4 text-sm ${cls}`}>
+	<slot />
+</aside>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -96,4 +96,17 @@ export const collections = {
 			cover: z.string().optional(), // local cover image path (e.g. /books/foo.jpg)
 		}),
 	}),
+	docs: defineCollection({
+		loader: glob({
+			pattern: '**/*.{md,mdx}',
+			base: './src/content/docs',
+		}),
+		schema: z.object({
+			title: z.string(),
+			description: z.string().optional(),
+			kind: z.enum(['reference', 'blueprint', 'template']),
+			order: z.number().optional(),
+			draft: z.boolean().optional(),
+		}),
+	}),
 };

--- a/src/content/docs/design-direction.mdx
+++ b/src/content/docs/design-direction.mdx
@@ -1,0 +1,69 @@
+---
+title: Design Direction
+description: How I set direction before touching a canvas — and what a good direction doc contains.
+kind: template
+order: 50
+draft: true
+---
+
+import Callout from '@components/Callout.astro'
+
+<Callout tone="scaffold">
+	**This page is a brainstorm scaffold.** The prompts below are the questions
+	I want to answer before publishing. When each section has a real answer,
+	drop the prompt and this callout.
+</Callout>
+
+An intro paragraph — what a design direction doc is, when in the project I
+reach for it, and how it differs from a project brief or a design review deck.
+
+## When I write one
+
+> _What triggers a direction doc? What phase of the project? What signals
+> I need one before proceeding?_
+
+## What it's answering
+
+> _The core question: given the brief, what's the design going to become,
+> and why this and not something else? What does "direction" mean vs.
+> "solution"?_
+
+## The parts
+
+### Framing
+
+> _Restating the problem in design terms. What we're solving that the
+> brief didn't quite name._
+
+### Principles for this project
+
+> _Not universal design principles — the three or so we're using as
+> tiebreakers on this specific project._
+
+### Directions considered
+
+> _Two or three, honestly. Each one with a summary, a strength, a weakness,
+> and the tradeoff it forces._
+
+### The recommended direction
+
+> _The pick, the reasoning, and what has to be true for it to work._
+
+### Open questions and risks
+
+> _Things I don't know yet, and what I'd need to learn to close them._
+
+## How I use it in the room
+
+> _Who reads this, when, and what I want them to do with it. How I present
+> it — walk through vs. hand out vs. embed in Figma._
+
+## What it isn't
+
+> _Not a spec, not a mockup, not a final direction. What it protects
+> against by existing._
+
+## Example
+
+> _Link or excerpt a filled-in example. Same reasoning as the brief —
+> without an example the template teaches nothing._

--- a/src/content/docs/interview-questions.mdx
+++ b/src/content/docs/interview-questions.mdx
@@ -1,0 +1,101 @@
+---
+title: Interview Questions
+description: A bank of questions I've collected for both sides of the interview table.
+kind: reference
+order: 10
+---
+
+A working list of questions I've asked or been asked in interviews, sorted by
+who's asking whom. Not a script — a menu I pull from depending on the
+conversation.
+
+## When I'm being interviewed
+
+Questions I use to figure out whether a role and company are actually a fit.
+
+### The company and the role
+- Tell me about the evolution of the company and where it stands today.
+- Where do you see the company heading in the next 2–4 years?
+- How do you see this role getting you there?
+- What are the biggest challenges the team faces at the moment? What are the team's strengths and weaknesses?
+- What are your expectations for any exit for the company?
+
+### The team
+- How would you rate the design team from 1–5? Why?
+- What will take us from _X_ to a 5 in the next year?
+- What does collaboration look like at the company?
+
+### The person across from me
+- What is it like working with you?
+- How many people have you promoted?
+- Tell me a story about how luck played a role in your life.
+- What's the best (or worst) piece of advice you've gotten?
+
+### The role's success and my fit
+- What metrics will you be using to show success for this role?
+- Based on our conversation today, how do you feel my background aligns to this role?
+- Do you have any doubts or concerns regarding my fit to this position that I can address before we end?
+- What are the next steps?
+
+### After the interview
+- Go on their website. Start a trial. Have opinions.
+- Send thank you notes.
+
+## When I'm interviewing someone
+
+### General
+- What's a personal opinion you've had and changed in the past year?
+- What motivates you to be a ______?
+- What are your career goals for the next few years?
+- How ambitious are you?
+- How do you practice and improve?
+- Without knowing our team, what unique perspectives do you think you bring?
+- What do you have unreasonably high standards for?
+- What is the most interesting puzzle you've had to work on?
+- What browser tabs do you currently have open right now?
+- In what way are you a troublemaker at work?
+- What is your favorite thing about yourself?
+
+### For designers
+
+#### Process and taste
+- What is your design process? How flexible is it?
+- What is "good design" to you? How do you know when you're there?
+- How do you define craft?
+- How do you grow your taste?
+- What are your principles for your own work?
+
+#### Collaboration
+- What strategies do you have for building a collaborative working relationship with Product Management? Engineering?
+- How do you balance scenarios where you know the feature you're working within could be improved, but the scope of your project is not to redo existing functionality?
+
+#### Shipping
+- A project you're working on is design complete in your mind. What happens next?
+- Internal and customer feedback will always exist for every project. How do you decide when design work is done?
+
+#### Design systems
+- What makes a good, useful design system to you?
+- What kind of work does it take to make a change to a design system?
+- Design systems, component libraries — what did you like? What did you not like?
+
+### For frontend engineers
+
+#### Code and quality
+- What is "good code" to you? How do you know when you're there?
+- What principles do you have for writing quality tests?
+- How do you know when you need more tests? When you've over-tested?
+- How do you balance scenarios where you know the code you're writing, or the code you need to modify, is not up to your quality standards, but improving it is not necessary to hit the goal of the project?
+
+#### Collaboration
+- What strategies do you have for building a collaborative working relationship with Design? Product Management?
+- How do you handle scenarios where task descriptions or acceptance criteria are not accurate, or need to change?
+
+#### The spectrum
+- On the front-of-the-frontend to back-of-the-frontend spectrum, where do you prefer working?
+
+  **UI-focused / front-of-the-frontend** — DOM & styling, accessibility,
+  animation, resilient CSS, browser & device testing, component unit tests.
+
+  **App-focused / back-of-the-frontend** — app logic, state, routing, caching,
+  auth, CRUD; data flow & APIs; load times; integration testing; bundlers,
+  frameworks, package versioning, CI/CD.

--- a/src/content/docs/leadership-blueprint.mdx
+++ b/src/content/docs/leadership-blueprint.mdx
@@ -1,0 +1,76 @@
+---
+title: Leadership Blueprint
+description: How I lead, what I commit to, and what I expect. Shared with the people I manage.
+kind: blueprint
+order: 20
+draft: true
+---
+
+import Callout from '@components/Callout.astro'
+
+<Callout tone="scaffold">
+	**This page is a brainstorm scaffold.** The prompts below are the questions
+	I want to answer before publishing. When each section has a real answer,
+	drop the prompt and this callout.
+</Callout>
+
+An intro paragraph — one or two sentences that frame who this is for (my
+direct reports, on day one) and how to read it. Voice should feel like me,
+not like a policy doc.
+
+## My leadership philosophy
+
+> _What am I actually trying to do as a leader — for the team, for the work,
+> for each person? In one or two sentences, not five._
+
+## What I commit to
+
+> _What can my team count on from me, unconditionally? Three to five items.
+> Not aspirational; things I'll actually do._
+
+## What I hold myself accountable to
+
+> _When I fall short of my commitments, what do I owe the team? How do I
+> want them to hold me to it?_
+
+## How I work with you
+
+> _My defaults on transparency, credit, protecting the team from politics,
+> tone, humor, availability. What behaviors am I modeling on purpose?_
+
+## What I ask of you
+
+> _The behaviors and posture I expect from the team. Not tasks — how to show
+> up. Include the mistakes I want people to be safe making._
+
+## How we'll work together
+
+### 1:1s
+
+> _What are 1:1s for? Whose meeting is it? How much prep do I expect? What's
+> off-limits?_
+
+### Career development
+
+> _How much of career growth is on me vs. on the person? What's my role
+> during a promotion push? What's my role when someone wants to leave?_
+
+### Feedback
+
+> _How I give feedback, how I want to receive it, what cadence, and what
+> "no surprises at review time" actually requires from me._
+
+### Decision-making
+
+> _When do I decide vs. delegate vs. defer? How do I want disagreement
+> surfaced?_
+
+### Time off and boundaries
+
+> _My position on hours, PTO, burnout, and what "the work will still be
+> here" means in practice._
+
+## What I'm still figuring out
+
+> _Optional but powerful: name the areas I'm still developing as a leader.
+> Signals honesty and invites feedback._

--- a/src/content/docs/long-term-goals.mdx
+++ b/src/content/docs/long-term-goals.mdx
@@ -1,0 +1,57 @@
+---
+title: Long-Term Goals
+description: A working answer to what I want my career to add up to.
+kind: blueprint
+order: 60
+draft: true
+---
+
+import Callout from '@components/Callout.astro'
+
+<Callout tone="scaffold">
+	**This page is a brainstorm scaffold.** The prompts below are the questions
+	I want to answer before publishing. When each section has a real answer,
+	drop the prompt and this callout.
+</Callout>
+
+An intro paragraph — this is a self-management tool, not a corporate
+career plan. Written for me first; useful to share with a manager during
+coaching conversations.
+
+## What drives me
+
+> _Motivations: what makes me want to come to work each day. Types of
+> problems that feel meaningful. Common threads in the work I'm proudest of._
+
+## What gives me energy vs. drains me
+
+> _Concrete: kinds of work, kinds of collaboration, kinds of environment.
+> The things I keep saying yes to and the things I keep regretting._
+
+## My values
+
+> _The principles I want to drive my decisions. Three-ish, each with a
+> sentence on why._
+
+## Long-term milestones
+
+> _Not job titles. States I want to reach: kinds of impact, kinds of
+> mastery, kinds of relationships. How I'll know if I'm living my values._
+
+## Current strengths
+
+> _My top strengths right now, honestly named, and how I apply them._
+
+## Current growth edges
+
+> _Where I want to grow. Not a weakness list — the things I'm actively
+> trying to get better at, and what "better" would look like._
+
+## The next 12 months
+
+> _Concrete goals for the coming year, tied to the milestones above.
+> What projects, what learning, what changes in how I work._
+
+## Revisit cadence
+
+> _When I'll re-read this and what I'll ask myself when I do._

--- a/src/content/docs/portfolio-formats.mdx
+++ b/src/content/docs/portfolio-formats.mdx
@@ -1,0 +1,95 @@
+---
+title: Portfolio Formats
+description: Three ways to show your work — and when each one earns its place.
+kind: reference
+order: 15
+---
+
+Not every piece in a portfolio needs to be a full case study. There are three
+tiers, and they serve different purposes at different points in the hiring
+process. Picking the wrong tier is the most common thing I see designers do
+to their own portfolio.
+
+The argument for why is in the essay
+[Not Everything Is a Case Study](/articles/not-everything-is-a-case-study).
+This is the reference version.
+
+## The three tiers
+
+### Showcase
+
+**What it is** — All visuals, minimal context. Dribbble shots, gallery
+grids, a single hero image with a caption.
+
+**When to use** — Craft-heavy work: visual, brand, motion, illustration.
+Anywhere the image _is_ the point.
+
+**When it fails** — Product design. A reviewer scanning your portfolio can't
+tell how you think from a screen alone.
+
+**Structure** — Image. Optional one-line caption. That's it.
+
+### Project Feature
+
+**What it is** — The middle ground. Enough context and images to understand
+the project, your role, and your thinking. Optimized for the first scan.
+
+**When to use** — This is the default for most work on a product-design
+portfolio. It's what a hiring manager reads while deciding whether to talk
+to you.
+
+**When it fails** — When it grows into a case study. If it doesn't fit on a
+single scroll on a laptop, it's the wrong tier.
+
+**Structure**
+
+- **Hook** — What was the situation, what did you work on, what changed. Two
+  or three sentences.
+- **Screens** — Enough visuals to build excitement before anyone reads a
+  word. Hero, before/after, a detail, mobile view.
+- **Context** — Company, timeline, team size. One or two sentences.
+- **Your role** — What you specifically did. Precise about scope and
+  collaboration.
+- **The design problem** — One core challenge. What you considered, what you
+  traded off, why you landed where you did.
+- **Outcomes** — Metrics if you have them. Qualitative results if you don't.
+  Optionally, what you'd do differently.
+
+### Case Study
+
+**What it is** — The deep, thorough walkthrough. Every phase, every decision,
+every outcome.
+
+**When to use** — Live, in the interview room. When someone has twenty
+minutes to an hour and their full attention.
+
+**When it fails** — On the portfolio site as the first thing a scanning
+reviewer sees. It's the right depth at the wrong moment.
+
+**Structure** — Its own topic. Not covered here.
+
+## Picking the right tier
+
+| Viewing context                                | Tier            |
+| ---------------------------------------------- | --------------- |
+| Recruiter or hiring manager, 30 seconds of scan | Project Feature |
+| Design-team review, ~5 minutes                  | Project Feature |
+| Live interview presentation                     | Case Study      |
+| Craft display (visual, brand, motion)           | Showcase        |
+
+## Signals your portfolio is on the wrong tier
+
+- Every project looks the same because they all have process sections,
+  research sections, and outcomes sections.
+- Nobody scrolls to your outcomes.
+- You feel the need to add a "TL;DR" at the top. That IS the project feature
+  — build it that way instead.
+- Your case study reads well but nobody's asking to talk to you.
+
+## What great collections do
+
+- Show range. Different problem types, scales, industries.
+- Sequence intentionally. The strongest piece leads.
+- Match the format to the viewing context, not to a template.
+- Include at least one project feature written like a design artifact — the
+  presentation itself is being evaluated.

--- a/src/content/docs/project-brief.mdx
+++ b/src/content/docs/project-brief.mdx
@@ -1,0 +1,57 @@
+---
+title: Project Brief
+description: What I think a good project brief actually has — and what I strip out.
+kind: template
+order: 40
+draft: true
+---
+
+import Callout from '@components/Callout.astro'
+
+<Callout tone="scaffold">
+	**This page is a brainstorm scaffold.** The prompts below are the questions
+	I want to answer before publishing. When each section has a real answer,
+	drop the prompt and this callout.
+</Callout>
+
+An intro paragraph — what a brief is _for_ in my head, and who I'm writing
+this for (PMs, designers, engineers starting a project together).
+
+## What a brief is for
+
+> _What decision does the brief unblock? What conversations should it
+> replace? What conversations does it start?_
+
+## The must-haves
+
+> _The two-to-four sections I refuse to skip. Why each one is load-bearing._
+
+## What I strip out
+
+> _Sections that show up in every template but almost always waste time or
+> mislead the team. Why they hurt more than they help._
+
+## What great briefs share
+
+> _Beyond structure: tone, length, level of specificity. Signs a brief is
+> going to actually get used vs. archived after kickoff._
+
+## What I do when the brief is wrong
+
+> _When acceptance criteria drift, or the problem statement stops matching
+> reality. How I renegotiate without derailing the team._
+
+## Signals a project doesn't need a brief
+
+> _When formality is overhead. When to swap the brief for a Slack thread
+> or a whiteboard._
+
+## A working outline
+
+> _My preferred order of sections — probably ~6, not ODD's ~10 — with a
+> one-line "what this section is answering" for each._
+
+## Example
+
+> _Link or excerpt a filled-in example I've written. Templates without
+> examples don't teach._

--- a/src/content/docs/t-shirt-sizing.mdx
+++ b/src/content/docs/t-shirt-sizing.mdx
@@ -1,0 +1,87 @@
+---
+title: T-Shirt Sizing
+description: A shared vocabulary for project size, for design and engineering.
+kind: reference
+order: 70
+---
+
+T-shirt sizing is a lightweight way to talk about project scope before you
+commit to dates. Everyone on the team — design, engineering, product — picks a
+size for a project, discusses where they disagree, and lands on a shared
+number. The size drives what artifacts are expected (brief, kickoff,
+review) and how many people show up.
+
+The sizes below are what I use as defaults. Teams should tune them.
+
+## Sizes
+
+### XS · Extra Small
+
+- **Design** — 1 designer, up to a day
+- **Engineering** — 1 engineer, less than one sprint
+- **Research** — none
+- **Brief** — not required
+- **Kickoff** — not required
+- **Example** — a copy tweak, a bug fix, a minor visual polish pass
+
+### S · Small
+
+- **Design** — 1 designer, 1–3 days
+- **Engineering** — 1 engineer, less than one sprint
+- **Research** — internal prototyping, no external testing
+- **Brief** — required (short)
+- **Kickoff** — optional
+- **Example** — a net-new but bounded feature, or a sizable change to an existing one
+
+### M · Medium
+
+- **Design** — 1 designer, 3–5 days
+- **Engineering** — 1 engineer, one sprint
+- **Research** — usability testing likely
+- **Brief** — required
+- **Kickoff** — required
+- **Example** — a new feature that touches an existing flow
+
+### L · Large
+
+- **Design** — 1 designer, 1–2 weeks
+- **Engineering** — 1 engineer, 1–2 sprints
+- **Research** — usability testing, likely upfront research
+- **Brief** — required
+- **Kickoff** — required
+- **Example** — a sizable new feature or a rework of an existing flow
+
+### XL · Extra Large
+
+- **Design** — 1+ designers, 2+ weeks
+- **Engineering** — 1+ engineers, 2+ sprints
+- **Research** — upfront research plus usability testing
+- **Brief** — required
+- **Kickoff** — required, cross-team
+- **Example** — a major new capability, or a rework of several flows
+
+## How to estimate
+
+1. **Break the project down.** List the deliverables, obvious dependencies,
+   and the constraints you already know about.
+2. **Size independently.** Design, engineering, and product each pick a
+   size without seeing the others' picks.
+3. **Compare and reconcile.** If sizes differ by one, pick the larger one.
+   If they differ by more, that's a signal the scope isn't shared yet —
+   talk before sizing.
+4. **Record the size.** It goes in the tracking tool and on the brief. Not
+   in someone's head.
+
+## When to use it
+
+- Sprint and roadmap planning
+- Deciding whether a project needs a brief or kickoff
+- Capacity conversations with leadership
+- Setting expectations with stakeholders before design starts
+
+## When to skip it
+
+- One-person, one-day work that doesn't leave the team
+- Genuinely urgent incidents where the artifact is worse than the fix
+- Early exploration where the shape of the work isn't known yet — size it
+  after the exploration, not before

--- a/src/content/docs/working-with-me.mdx
+++ b/src/content/docs/working-with-me.mdx
@@ -1,0 +1,60 @@
+---
+title: Working With Me
+description: How I show up as a teammate — what I do well, what I need, and how to give me feedback.
+kind: blueprint
+order: 30
+draft: true
+---
+
+import Callout from '@components/Callout.astro'
+
+<Callout tone="scaffold">
+	**This page is a brainstorm scaffold.** The prompts below are the questions
+	I want to answer before publishing. When each section has a real answer,
+	drop the prompt and this callout.
+</Callout>
+
+An intro paragraph — one or two sentences framing who this is for (new
+teammates, cross-functional partners) and how to read it. Not a résumé;
+a user manual.
+
+## How I think about the work
+
+> _What do I care about in the work itself? What do I consider "good"?
+> What am I bringing that's mine — perspective, taste, obsessions?_
+
+## Where I do my best work
+
+> _Conditions I need: kind of problem, kind of team, kind of pace, kind
+> of autonomy. What environments have burned me out?_
+
+## How I communicate
+
+> _Sync vs. async defaults. What I use Slack / meetings / docs / whiteboards
+> for. When I go quiet, what does that usually mean?_
+
+## What I'll bring to a project
+
+> _Concrete: what shows up when you work with me. Not a skills list —
+> the way I show up in the room, in the doc, in the review._
+
+## What I need from you
+
+> _What do I need from a manager, from PM, from engineering partners,
+> from other designers? Be specific enough that someone reading this
+> can actually do it._
+
+## How to give me feedback
+
+> _Preferred format, cadence, and level of directness. What lands well vs.
+> what lands sideways. What I do when I disagree with feedback._
+
+## What I'm working on
+
+> _Areas of my own craft or collaboration I'm actively trying to grow.
+> Invites teammates to help me._
+
+## Personal, briefly
+
+> _One or two lines — enough to make me a person, not a role. Where I am,
+> what I do outside work, what I read._

--- a/src/layouts/default.astro
+++ b/src/layouts/default.astro
@@ -5,10 +5,10 @@ import Footer from './Footer.astro';
 import Header from './Header.astro';
 import HTML from './html.astro';
 
-const { title } = Astro.props;
+const { title, noindex } = Astro.props;
 ---
 
-<HTML title={title}>
+<HTML title={title} noindex={noindex}>
 	<Header />
 	<main class="space-y-8">
 		<slot />

--- a/src/layouts/html.astro
+++ b/src/layouts/html.astro
@@ -4,7 +4,7 @@ import favicons from './favicon.html?raw';
 import '@assets/fonts/nudica.css';
 import '@assets/global.css';
 
-const { title: pageTitle } = Astro.props;
+const { title: pageTitle, noindex } = Astro.props;
 
 const titleParts: string[] = [];
 if (pageTitle) titleParts.push(pageTitle);
@@ -43,6 +43,7 @@ const title = titleParts.join(' → ');
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		{noindex && <meta name="robots" content="noindex, nofollow" />}
 		<title>{title}</title>
 		<Fragment set:html={favicons} />
 	</head>

--- a/src/layouts/prose.astro
+++ b/src/layouts/prose.astro
@@ -3,10 +3,10 @@ import Layout from './default.astro';
 
 const { title } = Astro.props.frontmanter || Astro.props;
 
-const { className } = Astro.props;
+const { className, noindex } = Astro.props;
 ---
 
-<Layout title={title}>
+<Layout title={title} noindex={noindex}>
 	<article class={`prose dark:prose-white mx-auto ${className}`}>
 		<slot />
 	</article>

--- a/src/pages/docs/[slug].astro
+++ b/src/pages/docs/[slug].astro
@@ -1,0 +1,29 @@
+---
+import { getCollection, render } from 'astro:content';
+
+import Prose from '@layouts/prose.astro';
+
+export async function getStaticPaths() {
+	const entries = await getCollection('docs');
+	return entries.map(entry => ({
+		params: { slug: entry.id },
+		props: { entry },
+	}));
+}
+
+const { entry } = Astro.props;
+const { title, description } = entry.data;
+const { Content } = await render(entry);
+---
+
+<Prose title={title} noindex>
+	<div class="mb-6 flex flex-col gap-1">
+		<h1 class="mb-0!">{title}</h1>
+		{description && <p class="text-subdued m-0! text-xl">{description}</p>}
+	</div>
+	<Content />
+	<hr class="border-hairline my-10" />
+	<p class="text-subdued text-sm">
+		<a href="/docs" class="hover">← All docs</a>
+	</p>
+</Prose>

--- a/src/pages/docs/index.astro
+++ b/src/pages/docs/index.astro
@@ -1,0 +1,80 @@
+---
+import { getCollection } from 'astro:content';
+
+import Section from '@components/Section.astro';
+import Layout from '@layouts/default.astro';
+
+const docs = (await getCollection('docs')).sort(
+	(a, b) => (a.data.order ?? 999) - (b.data.order ?? 999),
+);
+
+const kinds = [
+	{
+		key: 'blueprint',
+		label: 'Blueprints',
+		description:
+			'How I work — as a leader and as an IC. The kind of doc you send someone before they meet you.',
+	},
+	{
+		key: 'template',
+		label: 'Templates',
+		description:
+			'Answers to the questions I think a good project brief, design direction, or set of goals should cover.',
+	},
+	{
+		key: 'reference',
+		label: 'References',
+		description:
+			'Frameworks, banks of questions, and other material worth keeping close by.',
+	},
+] as const;
+---
+
+<Layout title="Docs" noindex>
+	<div>
+		<h1 class="mb-2 text-3xl font-bold">Docs</h1>
+		<p class="text-subdued mb-8 max-w-prose">
+			A working reference for how I think about design and engineering
+			work. Some are my own answers, others are frameworks I lean on.
+		</p>
+		<div class="space-y-10">
+			{
+				kinds.map(({ key, label, description }) => {
+					const items = docs.filter(d => d.data.kind === key);
+					if (!items.length) return null;
+					return (
+						<Section title={label}>
+							<p class="text-subdued mt-1 mb-3 max-w-prose text-sm">
+								{description}
+							</p>
+							<ul class="space-y-3">
+								{items.map(({ data: { title, description, draft }, id }) => (
+									<li>
+										<a
+											href={`/docs/${id}`}
+											class="hover group inline-block focus:outline-0"
+										>
+											<span class="flex items-baseline gap-2 text-xl font-medium">
+												{title}
+												{draft && (
+													<span class="text-subdued rounded-sm border border-current px-1 text-xs font-normal uppercase tracking-wide">
+														Draft
+													</span>
+												)}
+											</span>
+											{description && (
+												<span class="text-subdued block text-sm">
+													{description}
+												</span>
+											)}
+										</a>
+									</li>
+								))}
+							</ul>
+						</Section>
+					);
+				})
+			}
+		</div>
+	</div>
+</Layout>


### PR DESCRIPTION
## Summary

Revives the docs idea from the abandoned `docs` branch — but small. Eight docs, one entry point, no homepage link, `noindex` on every doc page.

## What's included

**References (complete)**
- `interview-questions` — merged from the old docs branch and expanded with newer prompts
- `portfolio-formats` — distilled from the [Not Everything Is a Case Study](/articles/not-everything-is-a-case-study) essay
- `t-shirt-sizing` — full framework write-up

**Brainstorm scaffolds (drafts)**
- `leadership-blueprint`, `working-with-me`, `long-term-goals`, `project-brief`, `design-direction`
- Each is section headers plus italic prompt questions. The intent is to answer them in place, then drop the `<Callout tone="scaffold">` and `draft: true` when ready.

## How it behaves

- `/docs` is the only entry point. No homepage link, no cross-linking between docs (yet).
- All doc pages carry `<meta name="robots" content="noindex, nofollow">` — reachable by URL, not by search.
- Drafts show on `/docs` with a `DRAFT` label so they're navigable while I fill them in.

## Structure

- Added `docs` collection to `src/content.config.ts` with `title`, `kind` (`blueprint` | `template` | `reference`), `order`, `draft` fields.
- New pages: `src/pages/docs/index.astro` (grouped hub) and `src/pages/docs/[slug].astro`.
- New `<Callout>` component (used by the scaffold banner).
- Layouts (`html`, `default`, `prose`) now accept a `noindex` prop that plumbs a `<meta name="robots">` tag.

## Test plan

- [ ] Visit the Netlify deploy preview at `/docs` — should show three groups (Blueprints / Templates / References) with 8 total items, five tagged `DRAFT`
- [ ] Click into a draft (e.g. `/docs/leadership-blueprint`) — should render section headers with italic prompt blockquotes and a "← All docs" link
- [ ] Click into a reference (e.g. `/docs/interview-questions`) — should render the full merged content
- [ ] View source on `/docs` — should include `<meta name="robots" content="noindex, nofollow">`
- [ ] View source on `/` — should NOT reference docs and should NOT include the robots noindex meta